### PR TITLE
Jpype2

### DIFF
--- a/ivy.xml
+++ b/ivy.xml
@@ -1,0 +1,11 @@
+<ivy-module version="2.0" xmlns:e="http://ant.apache.org/ivy/extra" xmlns:m="http://ant.apache.org/ivy/maven">
+    <info organisation="org.jpype" module="jpype"/>
+
+   <configurations defaultconf="deps">
+       <conf name="deps" description="binary jars"/>
+   </configurations>
+   
+   <dependencies>
+       <dependency org="org.apache.drill.exec" name="drill-jdbc-all" rev="1.17.0" conf="deps->default"/>
+   </dependencies>
+</ivy-module>

--- a/resolve.sh
+++ b/resolve.sh
@@ -1,0 +1,6 @@
+#!/bin/sh
+# This is used to pull dependencies needed for this package
+
+# drill has a bunch of dependencies, so we are going to use ivy to collect it all at once.
+wget -nc "https://repo1.maven.org/maven2/org/apache/ivy/ivy/2.4.0/ivy-2.4.0.jar" -P lib
+java -jar lib/ivy-2.4.0.jar -ivy ivy.xml -retrieve 'lib/[artifact]-[revision](-[classifier]).[ext]'

--- a/sqlalchemy_drill/jdbc.py
+++ b/sqlalchemy_drill/jdbc.py
@@ -22,7 +22,7 @@
 from __future__ import absolute_import
 from __future__ import unicode_literals
 import jpype
-import jpype.dbapi2 as jaydebeapi
+import jpype.dbapi2 as dbapi2
 import os
 import logging
 from .base import DrillDialect, DrillCompiler_sadrill
@@ -37,17 +37,16 @@ class DrillDialect_jdbc(DrillDialect):
 
     def __init__(self, *args, **kwargs):
         super(DrillDialect_jdbc, self).__init__(*args, **kwargs)
-        self.jdbc_driver_path = os.environ.get('DRILL_JDBC_DRIVER_PATH')
-        self.jdbc_jar_name = os.environ.get('DRILL_JDBC_JAR_NAME')
 
-        if self.jdbc_driver_path is None:
-            raise Exception('To connect to Drill via JDBC, you must set the DRILL_JDBC_DRIVER path to the location of the Drill JDBC driver.')
-
-        if self.jdbc_jar_name is None:
-            raise Exception(
-                'To connect to Drill via JDBC, you must set the DRILL_JDBC_JAR_NAME environment variable.')
-        print("-Djava.class.path=" + self.jdbc_driver_path + self.jdbc_jar_name)
-
+        # The user is responsible for starting the JVM with the class path, but we can
+        # do some sanity checks to make sure they are pointed in the right direction.
+        if not jpype.isJVMStarted():
+            raise Exception("The JVM must be started before connecting to a JDBC driver.")
+        try:
+            jpype.JClass("org.apache.drill.jdbc.Driver")
+        except TypeError:
+            err = "The drill JDBC driver class was not located in the CLASSPATH `%s`"%str(jpype.java.lang.System.getProperty('java.class.path'))
+            raise Exception(err)
 
     def initialize(self, connection):
         super(DrillDialect_jdbc, self).initialize(connection)
@@ -55,8 +54,7 @@ class DrillDialect_jdbc(DrillDialect):
     """
     Open a connection to a database using a JDBC driver and return
         a Connection instance.
-        jclassname: Full qualified Java class name of the JDBC driver.
-        url: Database url as required by the JDBC driver.
+        dsn: Database url as required by the JDBC driver.
         driver_args: Dictionary or sequence of arguments to be passed to
                the Java DriverManager.getConnection method. Usually
                sequence of username and password for the db. Alternatively
@@ -64,23 +62,16 @@ class DrillDialect_jdbc(DrillDialect):
                `password` would probably be included). See
                http://docs.oracle.com/javase/7/docs/api/java/sql/DriverManager.html
                for more details
-        jars: Jar filename or sequence of filenames for the JDBC driver
-        libs: Dll/so filenames or sequence of dlls/sos used as shared
-              library by the JDBC driver
         """
     def create_connect_args(self, url):
         if url is not None:
             params = super(DrillDialect, self).create_connect_args(url)[1]
-            driver = self.jdbc_driver_path + self.jdbc_jar_name
 
-            cargs = (self.jdbc_driver_name,
-                     self._create_jdbc_url(url),
-                     [params['username'], params['password']],
-                     driver)
-            cparams = {p: params[p] for p in params if p not in ['host', 'username', 'password', 'port']}
+            # We only need the dsn url as an argument
+            cargs = (self._create_jdbc_url(url), )
 
-            jpype.startJVM("-ea","-Djava.class.path=" + self.jdbc_driver_path + self.jdbc_jar_name)
-            #dbapi2.connect('jdbc:drill:drillbit=localhost:31010', driver="org.apache.drill.jdbc.Driver")
+            # Everything else is passed as keywords
+            cparams = {p: params[p] for p in params if p not in ['host', 'port']}
 
             logging.info("Cargs:" + str(cargs))
             logging.info("Cparams" + str(cparams))
@@ -95,6 +86,6 @@ class DrillDialect_jdbc(DrillDialect):
 
     @classmethod
     def dbapi(cls):
-        return jaydebeapi
+        return dbapi2
 
 dialect = DrillDialect_jdbc

--- a/sqlalchemy_drill/jdbc.py
+++ b/sqlalchemy_drill/jdbc.py
@@ -21,7 +21,8 @@
 
 from __future__ import absolute_import
 from __future__ import unicode_literals
-import jaydebeapi
+import jpype
+import jpype.dbapi2 as jaydebeapi
 import os
 import logging
 from .base import DrillDialect, DrillCompiler_sadrill
@@ -45,6 +46,8 @@ class DrillDialect_jdbc(DrillDialect):
         if self.jdbc_jar_name is None:
             raise Exception(
                 'To connect to Drill via JDBC, you must set the DRILL_JDBC_JAR_NAME environment variable.')
+        print("-Djava.class.path=" + self.jdbc_driver_path + self.jdbc_jar_name)
+
 
     def initialize(self, connection):
         super(DrillDialect_jdbc, self).initialize(connection)
@@ -75,6 +78,9 @@ class DrillDialect_jdbc(DrillDialect):
                      [params['username'], params['password']],
                      driver)
             cparams = {p: params[p] for p in params if p not in ['host', 'username', 'password', 'port']}
+
+            jpype.startJVM("-ea","-Djava.class.path=" + self.jdbc_driver_path + self.jdbc_jar_name)
+            #dbapi2.connect('jdbc:drill:drillbit=localhost:31010', driver="org.apache.drill.jdbc.Driver")
 
             logging.info("Cargs:" + str(cargs))
             logging.info("Cparams" + str(cparams))

--- a/test/test_jdbc.py
+++ b/test/test_jdbc.py
@@ -31,6 +31,7 @@ with engine.connect() as con:
 print("Now JDBC")
 jdbc_engine = create_engine('drill+jdbc://admin:password@localhost:31010')
 
+
 with jdbc_engine.connect() as con:
     rs = con.execute('SELECT * FROM cp.`employee.json` LIMIT 5')
     for row in rs:

--- a/test_jars.py
+++ b/test_jars.py
@@ -1,0 +1,16 @@
+# This is a simple test to see if the JDBC driver is available for use
+# Run "resolve.sh" prior to running this to install all of the required
+# drill dependencies.
+import jpype
+import jpype.imports
+
+jpype.startJVM('-ea', classpath='lib/*')
+
+# First lets see if we have everything in the class path
+print(jpype.java.lang.System.getProperty("java.class.path"))
+
+# Second lets see if the driver is loadable
+from org.apache.drill.jdbc import Driver
+
+# All good to go
+print("GOOD")

--- a/test_jdbc.py
+++ b/test_jdbc.py
@@ -1,0 +1,46 @@
+# This is the MIT license: http://www.opensource.org/licenses/mit-license.php
+#
+# Copyright (c) 2005-2012 the SQLAlchemy authors and contributors <see AUTHORS file>.
+# SQLAlchemy is a trademark of Michael Bayer.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy of this
+# software and associated documentation files (the "Software"), to deal in the Software
+# without restriction, including without limitation the rights to use, copy, modify, merge,
+# publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons
+# to whom the Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all copies or
+# substantial portions of the Software.
+
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR
+# PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE
+# FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+# OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+# DEALINGS IN THE SOFTWARE.
+
+from sqlalchemy import create_engine
+
+# It is usually not a good idea to bury starting the JVM in a library.  Doing so would
+# make it so that JPype can only be used in the module and not available for other things.
+# You would also have to handle cases were the JVM is already started or the JVM was started
+# with a different thread than main.
+import jpype
+#jpype.startJVM("-ea")
+jpype.startJVM("-ea", classpath="lib/*")
+
+#engine = create_engine('drill+sadrill://localhost:8047/dfs?use_ssl=False')
+#
+#with engine.connect() as con:
+#    rs = con.execute('SELECT * FROM cp.`employee.json` LIMIT 5')
+#    for row in rs:
+#        print(row)
+
+print("Now JDBC")
+jdbc_engine = create_engine('drill+jdbc://admin:password@localhost:31010')
+
+
+with jdbc_engine.connect() as con:
+    rs = con.execute('SELECT * FROM cp.`employee.json` LIMIT 5')
+    for row in rs:
+        print(row)


### PR DESCRIPTION
This was enough to get the driver to load successfully.   Not able to do any testing as I don't have drill database.

Now gives me
```
Now JDBC
SLF4J: Failed to load class "org.slf4j.impl.StaticLoggerBinder".
SLF4J: Defaulting to no-operation (NOP) logger implementation
SLF4J: See http://www.slf4j.org/codes.html#StaticLoggerBinder for further details.
WARNING: An illegal reflective access operation has occurred
WARNING: Illegal reflective access by oadd.javassist.util.proxy.SecurityActions (file:/mnt/c/cygwin64/home/nelson85/devel/open/sqlalchemy-drill/lib/drill-jdbc-all-1.17.0.jar) to method java.lang.ClassLoader.defineClass(java.lang.String,byte[],int,int,java.security.ProtectionDomain)
WARNING: Please consider reporting this to the maintainers of oadd.javassist.util.proxy.SecurityActions
WARNING: Use --illegal-access=warn to enable warnings of further illegal reflective access operations
WARNING: All illegal access operations will be denied in a future release
jpype.dbapi2.ConnectException: java.net.ConnectException: Connection refused

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
.......
sqlalchemy.exc.DBAPIError: (jpype.dbapi2.java.sql.SQLNonTransientConnectionException) java.sql.SQLNonTransientConnectionException: Failure in connecting to Drill: oadd.org.apache.drill.exec.rpc.RpcException: CONNECTION : oadd.io.netty.channel.AbstractChannel$AnnotatedConnectException: Connection refused: localhost/127.0.0.1:31010
(Background on this error at: http://sqlalche.me/e/dbapi)
```